### PR TITLE
Fix license header formatting and capitalization

### DIFF
--- a/spark/src/main/scala/software/amazon/glue/GlueIcebergSparkExtensions.scala
+++ b/spark/src/main/scala/software/amazon/glue/GlueIcebergSparkExtensions.scala
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 

--- a/spark/src/main/scala/software/amazon/glue/s3a/AnonymousAWSCredentialsProvider.java
+++ b/spark/src/main/scala/software/amazon/glue/s3a/AnonymousAWSCredentialsProvider.java
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 

--- a/spark/src/main/scala/software/amazon/glue/s3a/Constants.java
+++ b/spark/src/main/scala/software/amazon/glue/s3a/Constants.java
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 

--- a/spark/src/main/scala/software/amazon/glue/s3a/S3A.java
+++ b/spark/src/main/scala/software/amazon/glue/s3a/S3A.java
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 

--- a/spark/src/main/scala/software/amazon/glue/s3a/S3AFileStatus.java
+++ b/spark/src/main/scala/software/amazon/glue/s3a/S3AFileStatus.java
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 package software.amazon.glue.s3a;

--- a/spark/src/main/scala/software/amazon/glue/s3a/S3AInputStream.java
+++ b/spark/src/main/scala/software/amazon/glue/s3a/S3AInputStream.java
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 

--- a/spark/src/main/scala/software/amazon/glue/s3a/S3ClientFactory.java
+++ b/spark/src/main/scala/software/amazon/glue/s3a/S3ClientFactory.java
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 

--- a/spark/src/main/scala/software/amazon/glue/s3a/SimpleAWSCredentialsProvider.java
+++ b/spark/src/main/scala/software/amazon/glue/s3a/SimpleAWSCredentialsProvider.java
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 

--- a/spark/src/main/scala/software/amazon/glue/s3a/auth/delegation/S3ADtFetcher.java
+++ b/spark/src/main/scala/software/amazon/glue/s3a/auth/delegation/S3ADtFetcher.java
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 

--- a/spark/src/main/scala/software/amazon/glue/spark/redshift/ConvertIcebergToRedshiftRelation.scala
+++ b/spark/src/main/scala/software/amazon/glue/spark/redshift/ConvertIcebergToRedshiftRelation.scala
@@ -1,15 +1,15 @@
 /*
- * Copyright amazon.com, Inc. Or Its AFFILIATES. all rights reserved.
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
- * licensed under the apache License, version 2.0 (the "license").
- * you may not use this file except in Compliance WITH the license.
- * a copy of the license Is Located At
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
  *
- *  http://aws.amazon.Com/apache2.0
+ *  http://aws.amazon.com/apache2.0
  *
- * or in the "license" file accompanying this file. this File Is distributed
- * on an "as is" basis, Without warranties or conditions of any kind, EITHER
- * express or Implied. see the license for the specific language governing
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
 


### PR DESCRIPTION
Fix license header formatting and capitalization.
These changes align the license headers with the standard format used in the majority of project files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
