### PR TITLE
fix: use DefaultAwsRegionProviderChain

### DIFF
--- a/spark/src/main/scala/software/amazon/glue/spark/redshift/Utils.scala
+++ b/spark/src/main/scala/software/amazon/glue/spark/redshift/Utils.scala
@@ -17,7 +17,7 @@ package software.amazon.glue.spark.redshift
 
 import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration
-import com.amazonaws.regions.Regions
+import com.amazonaws.regions.{DefaultAwsRegionProviderChain, Regions}
 import com.amazonaws.services.redshiftdataapi.{AWSRedshiftDataAPI, AWSRedshiftDataAPIClient}
 import com.amazonaws.services.s3.model.{BucketLifecycleConfiguration, HeadBucketRequest}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3Client, AmazonS3URI}
@@ -318,7 +318,7 @@ private[redshift] object Utils {
     // Either the user didn't provide a region or its malformed. Try to use the
     // connector's region as the tempdir region since they are usually collocated.
     // If they aren't, S3's default provider chain will help resolve the difference.
-    val currRegion = Regions.getCurrentRegion()
+    val currRegion = new DefaultAwsRegionProviderChain().getRegion
 
     // If the user didn't provide a valid tempdir region and we cannot determine
     // the connector's region, the connector is likely running outside of AWS.
@@ -333,7 +333,7 @@ private[redshift] object Utils {
     }
 
     // If all else fails, pick a default region.
-    if (currRegion != null) currRegion.getName else Regions.US_EAST_1.getName
+    if (currRegion != null) currRegion else Regions.US_EAST_1.getName
   }
 
   def getDefaultTempDirRegion(tempDirRegion: Option[String]): String = {


### PR DESCRIPTION
Use DefaultAwsRegionProviderChain instead of Regions to get current region.
